### PR TITLE
Fix cjs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
-main.ts
+/main.ts
 dist
+/index.js

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "organisationsnummer",
   "description": "Validate Swedish organization numbers",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "homepage": "https://github.com/organisationsnummer/js",
   "author": {

--- a/test.ts
+++ b/test.ts
@@ -1,6 +1,7 @@
-const Personnummer = require('personnummer').default;
 const lib = require(process.env.FILE);
-const Organisationsnummer = lib.default ? lib.default : lib;
+const Organisationsnummer = process.env.FILE?.includes('esm')
+  ? lib.default
+  : lib;
 
 it('should validate valid organization numbers', () => {
   const numbers = ['556016-0680', '556103-4249', '5561034249', '559244-0001'];


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [x] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

We would like to export `export default Organisationsnummer` as `module.exports = Organisationsnummer` but ESBuild adds `default` as a property and we don't want it. This fixes it without touching the `tsconfig` and messing up the `esm` build.

**Related issue**

[@personnummer#175](https://github.com/personnummer/js/issues/468)

**Motivation**

<!-- Why should we accept this pull request? :) -->

**Checklist**

- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have read and accepted the **Code of conduct**
- [x] Tests passes.
- [ ] Style lints passes.
- [ ] Documentation of new public methods exists.
<!-- The following are only needed if this is a new feature. -->
<!-- - [ ] New tests added which covers the added code. -->
<!-- - [ ] Documentation is updated. -->
<!-- - [ ] This PR includes breaking changes. -->
