### PR TITLE
Fix org numbers that starts with 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "prettier": "^2.8.4",
         "rimraf": "^4.3.0",
         "typescript": "^4.9.5",
+        "undici": "^5.20.0",
         "vitest": "^0.29.2"
       },
       "funding": {
@@ -1206,6 +1207,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/cac": {
@@ -3283,6 +3296,15 @@
       "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
       "dev": true
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -3489,6 +3511,18 @@
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
       "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
       "dev": true
+    },
+    "node_modules/undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -4913,6 +4947,15 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "requires": {
+        "streamsearch": "^1.1.0"
       }
     },
     "cac": {
@@ -6435,6 +6478,12 @@
       "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
       "dev": true
     },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true
+    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -6579,6 +6628,15 @@
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
       "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
       "dev": true
+    },
+    "undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dev": true,
+      "requires": {
+        "busboy": "^1.6.0"
+      }
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "prettier": "^2.8.4",
     "rimraf": "^4.3.0",
     "typescript": "^4.9.5",
+    "undici": "^5.20.0",
     "vitest": "^0.29.2"
   },
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,11 +31,15 @@ class Organisationsnummer {
         throw new OrganisationsnummerError();
       }
 
-      const number = input.replace('-', '');
+      let number = input.replace('-', '');
 
       // May only be prefixed with 16.
-      if (match[1] && +match[1] !== 16) {
-        throw new OrganisationsnummerError();
+      if (match[1]) {
+        if (+match[1] !== 16) {
+          throw new OrganisationsnummerError();
+        } else {
+          number = number.slice(2);
+        }
       }
 
       // Third digit bust be more than 20.

--- a/test.ts
+++ b/test.ts
@@ -5,11 +5,17 @@ const Organisationsnummer = process.env.FILE?.includes('cjs')
   : (await import(process.env.FILE)).default;
 
 it('should validate valid organization numbers', () => {
-  const numbers = ['556016-0680', '556103-4249', '5561034249', '559244-0001'];
+  const numbers = [
+    '165560160680',
+    '556016-0680',
+    '556103-4249',
+    '5561034249',
+    '559244-0001',
+  ];
 
-  numbers.forEach((number) =>
-    expect(Organisationsnummer.valid(number)).toBeTruthy()
-  );
+  numbers.forEach((number) => {
+    expect(Organisationsnummer.valid(number)).toBeTruthy();
+  });
 });
 
 it('should validate invalid organization numbers', () => {
@@ -22,6 +28,7 @@ it('should validate invalid organization numbers', () => {
 
 it('should format organization numbers without separator', () => {
   const numbers = {
+    '165560160680': '5560160680',
     '559244-0001': '5592440001',
     '556016-0680': '5560160680',
     '556103-4249': '5561034249',
@@ -35,6 +42,7 @@ it('should format organization numbers without separator', () => {
 
 it('should format organization numbers with separator', () => {
   const numbers = {
+    '165560160680': '556016-0680',
     '559244-0001': '559244-0001',
     '556016-0680': '556016-0680',
     '556103-4249': '556103-4249',
@@ -61,6 +69,7 @@ it('should get type from organization numbers', () => {
 
 it('should get vat number for organization numbers', () => {
   const numbers = {
+    '165560160680': 'SE556016068001',
     '559244-0001': 'SE559244000101',
     '556016-0680': 'SE556016068001',
     '556103-4249': 'SE556103424901',


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [x] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

Fix org numbers that are prefixed with 16.

<!-- Issue which this PR is connected to, if any. -->

**Motivation**

Seems to be valid org numbers, so `parse` should support it.

**Checklist**

- [x] I have read the **CONTRIBUTING** document.
- [x] I have read and accepted the **Code of conduct**
- [x] Tests passes.
- [x] Style lints passes.
- [x] Documentation of new public methods exists.
<!-- The following are only needed if this is a new feature. -->
<!-- - [ ] New tests added which covers the added code. -->
<!-- - [ ] Documentation is updated. -->
<!-- - [ ] This PR includes breaking changes. -->
